### PR TITLE
Make the package laravel ^8.0|^9.0|^10.0 compatible and fix test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.0",
     "laravel/framework": "^8.0|^9.0|^10.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     }
   ],
   "require": {
-    "php": ">=5.5.9",
-    "laravel/framework": "~5.1|^6.0|^7.0|^8.0|^9.0|^10.0"
+    "php": ">=7.1",
+    "laravel/framework": "^8.0|^9.0|^10.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.8",
-    "mockery/mockery": "~0.9",
+    "phpunit/phpunit": "^9.5",
+    "mockery/mockery": "^1.4",
     "squizlabs/php_codesniffer": "~2.0"
   },
   "autoload": {

--- a/src/Localize/DeterminerManager.php
+++ b/src/Localize/DeterminerManager.php
@@ -19,10 +19,10 @@ class DeterminerManager extends Manager
     protected function createCookieDriver()
     {
         $determiner = new Determiners\Cookie(
-            $this->app['config']['localize-middleware']['cookie']
+            $this->container['config']['localize-middleware']['cookie']
         );
 
-        $determiner->setFallback($this->app['config']['app']['fallback_locale']);
+        $determiner->setFallback($this->container['config']['app']['fallback_locale']);
 
         return $determiner;
     }
@@ -35,10 +35,10 @@ class DeterminerManager extends Manager
     protected function createHostDriver()
     {
         $determiner = new Determiners\Host(
-            new Collection($this->app['config']['localize-middleware']['hosts'])
+            new Collection($this->container['config']['localize-middleware']['hosts'])
         );
 
-        $determiner->setFallback($this->app['config']['app']['fallback_locale']);
+        $determiner->setFallback($this->container['config']['app']['fallback_locale']);
 
         return $determiner;
     }
@@ -51,10 +51,10 @@ class DeterminerManager extends Manager
     protected function createParameterDriver()
     {
         $determiner = new Determiners\Parameter(
-            $this->app['config']['localize-middleware']['parameter']
+            $this->container['config']['localize-middleware']['parameter']
         );
 
-        $determiner->setFallback($this->app['config']['app']['fallback_locale']);
+        $determiner->setFallback($this->container['config']['app']['fallback_locale']);
 
         return $determiner;
     }
@@ -67,10 +67,10 @@ class DeterminerManager extends Manager
     protected function createHeaderDriver()
     {
         $determiner = new Determiners\Header(
-            $this->app['config']['localize-middleware']['header']
+            $this->container['config']['localize-middleware']['header']
         );
 
-        $determiner->setFallback($this->app['config']['app']['fallback_locale']);
+        $determiner->setFallback($this->container['config']['app']['fallback_locale']);
 
         return $determiner;
     }
@@ -83,10 +83,10 @@ class DeterminerManager extends Manager
     protected function createSessionDriver()
     {
         $determiner = new Determiners\Session(
-            $this->app['config']['localize-middleware']['session']
+            $this->container['config']['localize-middleware']['session']
         );
 
-        $determiner->setFallback($this->app['config']['app']['fallback_locale']);
+        $determiner->setFallback($this->container['config']['app']['fallback_locale']);
 
         return $determiner;
     }
@@ -98,7 +98,7 @@ class DeterminerManager extends Manager
      */
     protected function createStackDriver()
     {
-        $determiners = (new Collection((array) $this->app['config']['localize-middleware']['driver']))
+        $determiners = (new Collection((array) $this->container['config']['localize-middleware']['driver']))
             ->filter(function ($driver) {
                 return $driver !== 'stack';
             })
@@ -107,7 +107,7 @@ class DeterminerManager extends Manager
             });
 
         return (new Determiners\Stack($determiners))
-            ->setFallback($this->app['config']['app']['fallback_locale']);
+            ->setFallback($this->container['config']['app']['fallback_locale']);
     }
 
     /**
@@ -117,7 +117,7 @@ class DeterminerManager extends Manager
      */
     public function getDefaultDriver()
     {
-        $driver = $this->app['config']['localize-middleware']['driver'];
+        $driver = $this->container['config']['localize-middleware']['driver'];
 
         return is_array($driver) ? 'stack' : $driver;
     }

--- a/tests/Localize/DeterminerManagerTest.php
+++ b/tests/Localize/DeterminerManagerTest.php
@@ -1,30 +1,33 @@
 <?php
 
-namespace Tests\BenConstable\Localize;
+namespace Localize\BenConstable\Localize;
 
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Config;
 use Mockery;
-use PHPUnit_Framework_TestCase;
 use BenConstable\Localize\Determiners;
 use BenConstable\Localize\DeterminerManager;
+use PHPUnit\Framework\TestCase;
 
-class DeterminerManagerTest extends PHPUnit_Framework_TestCase
+class DeterminerManagerTest extends \Illuminate\Foundation\Testing\TestCase
 {
-    private $app;
+    protected $app;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->app = [
-            'config' => [
+        $this->app = Container::getInstance();
+
+        $this->app->offsetSet('config', [
                 'localize-middleware' => require(__DIR__ . '/../../src/config/localize-middleware.php'),
                 'app' => [
                     'fallback_locale' => 'de'
                 ]
-            ]
-        ];
+        ]);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
+
         Mockery::close();
     }
 
@@ -88,5 +91,10 @@ class DeterminerManagerTest extends PHPUnit_Framework_TestCase
         $manager = new DeterminerManager($this->app);
 
         $this->assertInstanceOf(Determiners\DeterminerInterface::class, $manager->driver());
+    }
+
+    public function createApplication()
+    {
+        return $this->app;
     }
 }

--- a/tests/Localize/Determiners/CookieTest.php
+++ b/tests/Localize/Determiners/CookieTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\BenConstable\Localize\Determiners;
+namespace Localize\BenConstable\Localize\Determiners;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BenConstable\Localize\Determiners\Cookie;
 
-class CookieTest extends PHPUnit_Framework_TestCase
+class CookieTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Localize/Determiners/HeaderTest.php
+++ b/tests/Localize/Determiners/HeaderTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\BenConstable\Localize\Determiners;
+namespace Localize\BenConstable\Localize\Determiners;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BenConstable\Localize\Determiners\Header;
 
-class HeaderTest extends PHPUnit_Framework_TestCase
+class HeaderTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Localize/Determiners/HostTest.php
+++ b/tests/Localize/Determiners/HostTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Tests\BenConstable\Localize\Determiners;
+namespace Localize\BenConstable\Localize\Determiners;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BenConstable\Localize\Determiners\Host;
 use Illuminate\Support\Collection;
 
-class HostTest extends PHPUnit_Framework_TestCase
+class HostTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Localize/Determiners/ParameterTest.php
+++ b/tests/Localize/Determiners/ParameterTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\BenConstable\Localize\Determiners;
+namespace Localize\BenConstable\Localize\Determiners;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BenConstable\Localize\Determiners\Parameter;
 
-class ParameterTest extends PHPUnit_Framework_TestCase
+class ParameterTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Localize/Determiners/SessionTest.php
+++ b/tests/Localize/Determiners/SessionTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Tests\BenConstable\Localize\Determiners;
+namespace Localize\BenConstable\Localize\Determiners;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use BenConstable\Localize\Determiners\Session;
 
-class SessionTest extends PHPUnit_Framework_TestCase
+class SessionTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Localize/Determiners/StackTest.php
+++ b/tests/Localize/Determiners/StackTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Tests\BenConstable\Localize\Determiners;
+namespace Localize\BenConstable\Localize\Determiners;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
 use BenConstable\Localize\Determiners\Stack;
 use BenConstable\Localize\Determiners\Cookie;
 use BenConstable\Localize\Determiners\Session;
 use BenConstable\Localize\Determiners\Parameter;
 
-class StackTest extends PHPUnit_Framework_TestCase
+class StackTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
Since we are depending on this package and it's obviously not maintained, we should take care of it as our code.

From the PR, already tagged 2.0.0 version, and it's going to be used in our app as soon as the framework is upgraded to version 8.x.

Since we bumped new version but never merged to master I pushed the required changes here. I would bump a mayor version from this PR so we know that is only used after the update.


